### PR TITLE
Updated chapter 07

### DIFF
--- a/07 - Instantiate Test/code/cw-starter/src/contract.rs
+++ b/07 - Instantiate Test/code/cw-starter/src/contract.rs
@@ -56,8 +56,8 @@ mod tests {
     use cosmwasm_std::attr;
     use cosmwasm_std::testing::{mock_dependencies, mock_env, mock_info};
 
-    pub const ADDR1: &str = "ADDR1";
-    pub const ADDR2: &str = "ADDR2";
+    pub const ADDR1: &str = "juno1xxx";
+    pub const ADDR2: &str = "juno1yyy";
 
     #[test]
     fn test_instantiate() {


### PR DESCRIPTION
**Request to update the value for ADDR1 & ADDR2 so that tests pass**

If these addresses remained as "ADDR1" and "ADDR2", test will fail because addr_validate() fails inside the instantiate function

If these are changed to something like an actual cosmos address, "juno1xxx", or even just "jun", then these addresses will pass the addr_validate() function and the test can run

I think this has to do with the addr_canonicalize() function within the addr_validate() function but I'm not sure