### PR TITLE
[chore] Fix spelling mistakes

### DIFF
--- a/01 - Prelude/README.md
+++ b/01 - Prelude/README.md
@@ -1,6 +1,6 @@
 # Part One - Prelude
 
-So you want to get started writing CosmWasm smart contracts? Where do I start? What do I need? Can I even do this? Well firstly I’m going to go through some base knowledge which I expect you to have. Don’t worry if you don’t have these yet, these will be accompanied by links to get you in the right direction!
+So you want to get started writing CosmWasm smart contracts? Where do I start? What do I need? Can I even do this? Well, firstly I’m going to go through some base knowledge which I expect you to have. Don’t worry if you don’t have these yet, these will be accompanied by links to get you in the right direction!
 
 1. Ability to write rust code OR previous experience in learning programming languages on the fly
    - I recommend either having experience learning languages fast. Or if picking up rust for the first time running through some tutorials
@@ -12,12 +12,12 @@ So you want to get started writing CosmWasm smart contracts? Where do I start? W
      - [Traversy Media Crash Course](https://www.youtube.com/watch?v=SWYqp7iY_Tc)
      - [FreeCodeCamp Course](https://www.youtube.com/watch?v=RGOj5yH7evk)
 1. Comfortable using a terminal and CLI
-   - We will be running alot of commands from the terminal. Preferably you should use a Unix terminal.
+   - We will be running a lot of commands from the terminal. Preferably you should use a Unix terminal.
    - I recommend a Mac (Pre-M1 Chipset) or an Ubuntu work machine.
      - A workaround for windows is to use WSL Ubuntu. A tutorial for this is [here](https://www.youtube.com/watch?v=X-DHaQLrBi8)
 
-Right that seems like a lot but I need to make these assumptions, this will be talking about smart contract structure and coding. It will not be explaining what an if statement does, calling functions etc.
+Right, that seems like a lot but I need to make these assumptions, this will be talking about smart contract structure and coding. It will not be explaining what an if statement does, calling functions etc.
 
 Learning will take time, but take it at your own pace. Don’t burn yourself out, take regular breaks and pick up where you left off. This is instrumental if you feel yourself getting frustrated, it’s time to do something else.
 
-Also I promise sections will be smaller from now, I just had to cover my bases.
+Also, I promise sections will be smaller from now, I just had to cover my bases.

--- a/02 - Environment Setup/README.md
+++ b/02 - Environment Setup/README.md
@@ -1,6 +1,6 @@
 # Part Two - Environment Setup
 
-So you think you’re ready to start! Now we need to setup our development environment. First things first, text editors. I’ll rattle a few off for those that skipped ahead.
+So you think you’re ready to start? Now we need to set up our development environment. First things first, text editors. I’ll rattle a few off for those that skipped ahead.
 
 1. IntelliJ with Rust Plugin - [Setup Guide](https://www.youtube.com/watch?v=H_-L7sjLcH8)
 1. VSCode - [Setup Guide](https://www.youtube.com/watch?v=aYsUBddY7KY)
@@ -11,7 +11,7 @@ So we have our trusty text editor, it’s time for us to generate some boilerpla
 
 ## Ensuring Rustup is Installed
 
-Firstly we're going to need to ensure rustup is setup. To do this run the following commands in your terminal:
+Firstly we're going to need to ensure rustup is set up. To do this run the following commands in your terminal:
 
 ```bash
 rustup default stable
@@ -56,7 +56,7 @@ Using an older or a different branch:
 cargo generate --git https://github.com/CosmWasm/cw-template.git --branch <BRANCH_NAME> --name <PROJECT_NAME>
 ```
 
-For compatibility I am going to use an older version using the branch flag. This means if you are following along (you should be) we will be using the same package versions.
+For compatibility, I am going to use an older version using the branch flag. This means if you are following along (you should be) we will be using the same package versions.
 
 The version I will be using is `1.0-minimal`. This version has minimal boilerplate so we won't have to delete much, although it isn't the latest version. So run the command:
 
@@ -121,7 +121,7 @@ Once complete the output should look something like the following:
 ✨   Done! New project created /Path/To/Whereever/cosmwasm-zero-to-hero/02 - Environment Setup/code/cw-starter
 ```
 
-Let's verify it's all setup correctly by running some commands:
+Let's verify it's all set up correctly by running some commands:
 
 ```bash
 # Change directory to root directory of the contract
@@ -135,6 +135,6 @@ cargo schema
 cargo wasm
 ```
 
-We are now setup, so open this folder in your preferred text editor and we'll move on to the next section!
+We are now set up, so open this folder in your preferred text editor and we'll move on to the next section!
 
 The code for this section is available under the `code` directory. This will be standard for chapters going forward.

--- a/03 - What Are All These Files/README.md
+++ b/03 - What Are All These Files/README.md
@@ -1,6 +1,6 @@
 # Part Three - What Are All These Files
 
-So we now have our contract open in our preferred editor. Let's talk the file structure.
+So we now have our contract open in our preferred editor. Let's talk about the file structure.
 
 ```bash
 cw-starter/ # Root

--- a/04 - Can We Write Code Now/README.md
+++ b/04 - Can We Write Code Now/README.md
@@ -1,10 +1,10 @@
 # Part Four - Can We Write Code Now
 
-No we're not going to write code this chapter. Instead I am going to give an overview of what we will be building.
+No, we're not going to write code for this chapter. Instead, I am going to give an overview of what we will be building.
 
 ## On Chain Polls
 
-As our first project we're going to build and store polls on chain. Its functionality is as follows:
+As our first project, we're going to build and store polls on the chain. Its functionality is as follows:
 
 -   Any user can create a poll.
 -   Any user can vote on a poll.
@@ -13,14 +13,14 @@ As our first project we're going to build and store polls on chain. Its function
 For a textual example I will talk through a scenario with some users:
 
 1. User A can create a poll for example:
-    - What Cosmos coin is your favourite?
+    - What Cosmos coin is your favorite?
         1. Juno
         1. Osmosis
         1. Cosmos Hub
-2. User A decides to vote on their own poll, they vote `Juno`
-3. User B can also vote on the poll, they vote `Cosmos Hub`
+2. User A decides to vote on their own poll, they vote for `Juno`
+3. User B can also vote on the poll, they vote for `Cosmos Hub`
 4. After a certain amount of time User A (as the owner of the poll) can close the poll. User A closes the poll
 5. User C attempts to vote on a closed poll. They cannot
-6. The poll results are now visible for everyone to see on chain
+6. The poll results are now visible for everyone to see on the chain
 
-In the next chapter I promise we will write some code!
+In the next chapter, I promise we will write some code!

--- a/05 - State/README.md
+++ b/05 - State/README.md
@@ -1,8 +1,8 @@
 # Part Five - State
 
-We are finally getting to writing code! So lets get started, make sure you have your generated `cw-starter` project open in your text editor.
+We are finally getting to writing code! So let's get started, make sure you have your generated `cw-starter` project open in your text editor.
 
-Lets start in the `src/state.rs` file. Upon opening it you should see code like the following:
+Let's start in the `src/state.rs` file. Upon opening it you should see code like the following:
 
 ```rust
 use schemars::JsonSchema;
@@ -24,14 +24,14 @@ Let's talk through this section by section.
 
 The first 5 lines of code are importing other structs, interfaces and functions from other packages. To give a quick overview without getting bogged down too much:
 
--   JsonSchema allows structs to be serialized and deserialised to and from JSON
+-   JsonSchema allows structs to be serialized and deserialized to and from JSON
 -   Deserialize and Serialize provide the serialization described above.
 -   Addr is a Cosmos address, under the hood it is simply a string.
--   Item is a helper provided by storage plus. It effectively means we can store an item in storage. In this case the `STATE` variable is an `Item` which stores a singular `State` struct.
+-   Item is a helper provided by storage plus. It effectively means we can store an item in storage. In this case, the `STATE` variable is an `Item` that stores a singular `State` struct.
 
-We want to make some changes to this, let's rename it accordingly. I prefer my global state to be called `Config` as it is the configuration of my contract. Let's do this now and remove the `count` and `owner` variable from the struct and rename it to `Config`. Lets also rename `STATE` to `CONFIG`.
+We want to make some changes to this, let's rename it accordingly. I prefer my global state to be called `Config` as it is the configuration of my contract. Let's do this now and remove the `count` and `owner` variable from the struct and rename it to `Config`. Let's also rename `STATE` to `CONFIG`.
 
-It should now look like:
+It should now look like this:
 
 ```rust
 use schemars::JsonSchema;
@@ -48,7 +48,7 @@ pub struct Config {
 pub const CONFIG: Item<Config> = Item::new("config");
 ```
 
-Now let's think what global configs we want, we probably want a poll admin of some sort. Let's store this as an address in config.
+Now let's think about what global configs we want, we probably want a poll admin of some sort. Let's store this as an address in config.
 
 ```rust
 // Previous code omitted
@@ -81,14 +81,14 @@ So in Smart Contract and Rust terms what does that look like?
     - These transactions are signed for and are publically viewable, they also have the user's address attached.
     - We will use the user's address to store as the creator! (We can use that `Addr` type I described earlier)
 2. Question
-    - In simple terms a question is a string of characters.
+    - In simple terms, a question is a string of characters.
     - We will use the `String` type to store this.
     - An example of a string is `"The quick brown fox jumped over the lazy dog."`.
 3. Options
     - This is a tricky one and not one obviously available.
     - Some users of other programming languages may suggest using a `Map` structure however these cannot be stored in cosmwasm storage plus.
     - What we will use instead is a Vector (list) of pairs (tuples of length 2).
-        - For the poll example above the options vector will look like:
+        - For the poll example above the options vector will look like this:
         - [("Juno", 2), ("Osmosis", 1), ("Cosmos Hub", 3)]
         - The first element of each tuple is the option, and the second element is the count.
         - In Rust we will use a `Vec<(String, u64)>`
@@ -109,7 +109,7 @@ pub struct Poll {
 
 Some of you may notice a problem we have in our model. How do we keep track of who has already voted and what they voted for?
 
-The answer is simple, we will use a secondary structure. A `Ballot` this ballot will simply store what option they voted for. (Don't worry if you're wondering where we store who casted this ballot, I'll get to that later).
+The answer is simple, we will use a secondary structure: `Ballot`. This ballot will simply store what option they voted for. (Don't worry if you're wondering where we store who cast this ballot, I'll get to that later).
 
 Let's place this `Ballot` below the `Poll` struct.
 
@@ -125,15 +125,15 @@ pub struct Ballot {
 
 So we have defined our structs, but we still do not store them. As explained earlier we can store an `Item` but what if we want multiple?
 
-We achieve this by using a `Map`, this interface is provided by `cw-storage-plus` and allows storage of values with keys. If you are unfamiliar with a `Map` datastructure I recommend you do some reading on it.
+We achieve this by using a `Map`, this interface is provided by `cw-storage-plus` and allows storage of values with keys. If you are unfamiliar with a `Map` data structure I recommend you do some reading on it.
 
-So how do these maps work! Well firstly we need to define one, so let's talk through logic. Each poll is going to need a unique identifier to act as the key, for simplicities sake we are going to use a UUID that can be generated client side. This will be a `String` key.
+So how do these maps work? Well firstly we need to define one, so let's talk through logic. Each poll is going to need a unique identifier to act as the key, for simplicities sake we are going to use a UUID that can be generated client side. This will be a `String` key.
 
-So how do we defined it?
+So how do we define it?
 
-Well let's talk you throught it.
+Well, let's talk you through it.
 
-Firstly at the top of the file we need to modify one of the imports. Change:
+Firstly at the top of the file, we need to modify one of the imports. Change:
 
 ```rust
 use cw_storage_plus::Item;
@@ -147,7 +147,7 @@ use cw_storage_plus::{Item, Map};
 
 Now we import both `Item` and `Map` from `cw-storage-plus`.
 
-So how we defined a `Map` that we can use in our contract? Let's place it below our config `Item`.
+So how do we define a `Map`` that we can use in our contract? Let's place it below our config `Item`.
 
 ```rust
 // Previous code omitted
@@ -160,13 +160,13 @@ pub const POLLS: Map<String, Poll> = Map::new("polls");
 
 We also need to give it a string parameter for the storage key, let's simply give it the string `"polls"`.
 
-Now lets handle the `Ballot` storage. This is also going to be a `Map` but let's give our model a thought a second.
+Now, let's handle the `Ballot` storage. This is also going to be a `Map` but let's give our model thought for a second.
 
 One user can vote on many polls.
 
 So how can we store a user's vote across multiple polls?
 
-We're going to use a composite key, (similar to the tuple options defined earlier). This composite key will be in the format of `(Addr, String)`. Where `Addr` is the address of the voter, and `String` is the `Poll` UUID this vote is for.
+We're going to use a composite key, (similar to the tuple options defined earlier). This composite key will be in the format of `(Addr, String)`. Where `Addr` is the address of the voter and `String` is the `Poll` UUID this vote is for.
 
 So let's define this map below our `POLLS` map, remember to give it a storage key.
 
@@ -176,7 +176,7 @@ pub const POLLS: Map<String, Poll> = Map::new("polls");
 pub const BALLOTS: Map<(Addr, String), Ballot> = Map::new("ballots");
 ```
 
-Right we have finished coding for this one! Hopefully you learnt how to write custom structs and how to store them in storage.
+Right we have finished coding for this one! Hopefully, you learned how to write custom structs and how to store them in storage.
 
 Disclaimer! If you currently run any command such as `cargo test` or `cargo wasm` the build will break! Don't worry this is expected as we have modified our storage code without changing code on the contract side.
 

--- a/06 - Instantiate/README.md
+++ b/06 - Instantiate/README.md
@@ -4,13 +4,13 @@ Firstly I mentioned how I broke the build last time! Let's fix that.
 
 ## Spring Cleaning
 
-So how did I break the build? Well we renamed the `STATE` variable to `CONFIG` and this `STATE` variable is imported in `examples/schema.rs`.
+So how did I break the build? Well, we renamed the `STATE` variable to `CONFIG` and this `STATE` variable is imported in `examples/schema.rs`.
 
 It no longer exists so Rust throws an error!
 
-Let's got to `examples/schema.rs` and fix this.
+Let's go to `examples/schema.rs` and fix this.
 
-To fix simply find the line that looks like:
+To fix simply find the line that looks like this:
 
 ```rust
 use cw_starter::state::State;
@@ -81,9 +81,9 @@ cargo wasm
 
 ## Instantiating a Contract
 
-When contracts are stored on chain they must be instantiated. I cover storing contracts on chain in a later section.
+When contracts are stored on the chain they must be instantiated. I cover storing contracts on a chain in a later section.
 
-Instantiating a contract is like creating an object in other languages, however it is achieved by a special message.
+Instantiating a contract is like creating an object in other languages, however, it is achieved by a special message.
 
 This message is an `InstantiateMsg` located under `src/msg.rs`.
 
@@ -91,15 +91,15 @@ Let's add something to it!
 
 ### The InstantiateMsg
 
-What if when a user instantiates the contract, they can specify an admin but if they do not it defaults to them.
+What if when a user instantiates the contract, they can specify an admin but if they do not it defaults to them?
 
-How can we achieve this in Rust? Enter the `Option` structure. For example: `Option<String>` can either be a String or null.
+How can we achieve this in Rust? Enter the `Option` structure. For example `Option<`String>` can either be a String or null.
 
 This is perfect for our use case! You may wonder why we do not use `Option<Addr>` this is due to validation, we want to check what the user is passing us is a valid address. I will show you how to do this in code.
 
-Firstly lets add this option to our `InstantiateMsg`.
+Firstly let's add this option to our `InstantiateMsg`.
 
-Currently our `InstantiateMsg` looks like:
+Currently, our `InstantiateMsg`` looks like this:
 
 ```rust
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
@@ -146,9 +146,9 @@ pub fn instantiate(
 // Following code omitted
 ```
 
-We're going to correct this now and actually implement it! Currently it simply throws an error saying it's not implemented.
+We're going to correct this now and implement it! Currently, it simply throws an error saying it's not implemented.
 
-To start with lets use a standard called `cw2`, cw2 allows contracts to store a version and name. (The commented out parts).
+To start with let's use a standard called `cw2`, cw2 allows contracts to store a version and name. (The commented-out parts).
 
 Firstly let's uncomment those:
 
@@ -170,7 +170,7 @@ pub fn instantiate(
 // Following code omitted
 ```
 
-Now let's store them using `cw2`, first we have to import a helper function `set_contract_version`:
+Now let's store them using `cw2`, first, we have to import a helper function `set_contract_version`:
 
 ```rust
 // Previous code omitted
@@ -199,17 +199,17 @@ pub fn instantiate(
 As we have modified the instantiate arguments, now's an ideal time to talk through them:
 
 -   `deps` - The dependencies, this contains your contract storage, the ability to query other contracts and balances, and some API functionality.
--   `env` - The environment, this contains contract information such as its address, block information such as current height and time, as well as some optional transaction info.
+-   `env` - The environment, contains contract information such as its address, block information such as current height and time, as well as some optional transaction info.
 -   `info` - Message metadata, contains the sender of the message (`Addr`) and the funds sent with it a `Vec<Coin>`.
 -   `msg` - The `InstantiateMsg` you define in `src/msg.rs`.
 
-So we set some contract metadata but we still haven't implemented any logic. Alright let's create our `Config` struct and store it. Make sure you import the struct itself and the storage:
+So we set some contract metadata but we still haven't implemented any logic. Alright, let's create our `Config` struct and store it. Make sure you import the struct itself and the storage:
 
 ```rust
 use crate::state::{Config, CONFIG};
 ```
 
-Alright we're ready to set our `Config` firstly lets use this instantiate message to work out who our admin is going to be. We can do that using:
+Alright, we're ready to set our `Config` firstly let's use this instantiate message to work out who our admin is going to be. We can do that using:
 
 ```rust
 // Previous code omitted
@@ -234,22 +234,22 @@ pub fn instantiate(
 // Following code omitted
 ```
 
-Alright that's a lot of code. Let's talk you through it step by step.
+Alright, that's a lot of code. Let's talk you through it step by step.
 
 So the first two lines after `set_contract_version` unwrap our `Option` field and if it is `null` sets it to `info.sender.to_string()` which is the message sender's address as a string.
 
 Rust features a lot of unwrapping of errors and providing defaults, so I recommend you understand this pattern.
 
-In this case if we gave it `null` in our instantiate as the admin, it would be set to the sender. Otherwise it would use whatever value we passed it.
+In this case, if we gave it `null` in our instantiate as the admin, it would be set to the sender. Otherwise, it would use whatever value we passed it.
 
-It then validates the address by passing it as a `&str` to the `deps.api.addr_validate()` function. This validates if an address is valid and throws an error otherwise. We handle this error by proceeding the call with a `?` this automatically unwraps and throws the error if one is given. This means an `Invalid Address` error will be thrown back to the user if they provide an invalid one.
+It then validates the address by passing it as a `&str` to the `deps.api.addr_validate()` function. This validates if an address is valid and throws an error otherwise. We handle this error by proceeding with the call with a `?` this automatically unwraps and throws the error if one is given. This means an `Invalid Address` error will be thrown back to the user if they provide an invalid one.
 
 The next line creates a `Config` struct with our now validated admin address as the admin. We have to clone the validated address to avoid moving values.
 
-The line following that stores it in our `CONFIG` storage. (Ensure you have imported `CONFIG` from `state.rs`). It does this by calling it with `deps.storage` which is our contracts storage and giving it the address of our newly created config variable. It does this by preceeding it with the `&` character.
+The line following that stores it in our `CONFIG` storage. (Ensure you have imported `CONFIG` from `state.rs`). It does this by calling it with `deps.storage` which is our contracts storage and giving it the address of our newly created config variable. It does this by preceding it with the `&` character.
 
 The final line is our return line indicated by no `;`. This returns a success using the `Ok` and `Result` structure.
 
-Within the `Ok` structure we create a response using various builder methods. We add two attributes, which for simple understanding are similar to HTTP headers. Get into a habit of writing good attributes as they help a lot with providing metadata to a front end. In this case we add two, one of which tells the user what 'endpoint' they called and the other tells the user who the admin of the contract is.
+Within the `Ok` structure, we create a response using various builder methods. We add two attributes, which for simple understanding are similar to HTTP headers. Get into a habit of writing good attributes as they help a lot with providing metadata to the front end. In this case, we add two, one of which tells the user what 'endpoint' they called and the other tells the user who the admin of the contract is.
 
-We have implemented our first entry point of our contract! In the next section we will implement tests for it! Tests are vital for smart contracts.
+We have implemented the first entry point of our contract! In the next section, we will implement tests for it! Tests are vital for smart contracts.

--- a/07 - Instantiate Test/README.md
+++ b/07 - Instantiate Test/README.md
@@ -1,12 +1,12 @@
 # Part Seven - Instantiate Test
 
-Alright now we have implemented instantiating our contract let's get to testing it!
+Alright, now we have implemented instantiating our contract let's get to testing it!
 
-Unit tests are vital to smart contract development, every developer should be implementing tests and striving to maximise test coverage. This can be achieved by both Unit-tests and integration tests.
+Unit tests are vital to smart contract development, every developer should be implementing tests and striving to maximize test coverage. This can be achieved by both Unit-tests and integration tests.
 
-We'll cover both in this series but for now let's get to unit testing.
+We'll cover both in this series but for now, let's get to unit testing.
 
-So let's look at our `contract.rs` file, at the bottom there should be something that looks like:
+So let's look at our `contract.rs` file, at the bottom, there should be something that looks like this:
 
 ```rust
 #[cfg(test)]
@@ -32,7 +32,7 @@ mod tests {
 }
 ```
 
-Just to touch on the topic of mocking, mocking is faking values for the sake of testing. For example `mock_dependencies` can fake the value needed for the `DepsMut` type for our `instantiate` call.
+Just to touch on the topic of mocking, mocking is faking values for the sake of testing. For example, `mock_dependencies` can fake the value needed for the `DepsMut` type for our `instantiate` call.
 
 The two global address variables we will use when mocking info, for this case setting admin correctly.
 
@@ -99,7 +99,7 @@ mod tests {
 }
 ```
 
-Alright those next two parts should seem somewhat familiar! The first part is the `InstantiateMsg` we wrote. In this case we provide `None` as the admin meaning the sender (`ADDR1`) will be the admin.
+Alright those next two parts should seem somewhat familiar! The first part is the `InstantiateMsg` we wrote. In this case, we provide `None` as the admin meaning the sender (`ADDR1`) will be the admin.
 
 The part after that is simply calling our `instantiate` function and capturing the response. We unwrap the `Result` wrapper to assert success as we expect it to succeed.
 
@@ -107,15 +107,15 @@ That leaves the `res` variable with type `Response` we created the response with
 
 So we expect this `res` variable to have two attributes, one of which is simply `("action", "instantiate")` and the other we expect to be `("admin", "ADDR1")` as we provided `None` for the admin in our instantiate message.
 
-If only there was a way we could `assert` that this was `equal` to what we expect.
+If only there was a way we could `assert` that this was `equal` to what we expected.
 
 Can you see where I am getting at?
 
-If not that's fine, enter `assert_eq!`. `assert_eq!` is a macro used in testing to assert two values are the same. It will panic otherwise and fail the test.
+If not that's fine, enter `assert_eq`, `assert_eq!` is a macro used in testing to assert two values are the same. It will panic otherwise and fail the test.
 
-Now let's show you how to use it. A `Response` object has a member variable which is a vector of attributes (`Vec<Attribute>`). In our case this can be accessed by using `res.attributes`. Now we want to assert that this is equal to another vector of attributes.
+Now let's show you how to use it. A `Response` object has a member variable which is a vector of attributes (`Vec<Attribute>`). In our case, this can be accessed by using `res.attributes`. Now we want to assert that this is equal to another vector of attributes.
 
-Alright enough text let's just show you how.
+Alright, enough text let's just show you how.
 
 ```rust
 #[cfg(test)]
@@ -144,11 +144,11 @@ mod tests {
 }
 ```
 
-Alright so the first part makes sense right! So we want to assert two values are equal, one of these values is `res.attributes` (the first parameter). The other is a vector which we have hardcoded, as we expect the values to be equal. (Note: `vec![]` is a handy macro to make vectors inline). Also the `attr` function is simply a helper function that creates an `Attribute` struct for you. It's call signature is as follows `attr(key, value)`.
+Alright so the first part makes sense right? So we want to assert two values are equal, one of these values is `res.attributes` (the first parameter). The other is a vector that we have hardcoded, as we expect the values to be equal. (Note: `vec![]` is a handy macro to make vectors inline). Also, the `attr` function is simply a helper function that creates an `Attribute` struct for you. Its call signature is as follows `attr(key, value)`.
 
-So now let's run `cargo test`, you should be met by the 1 test passing again. However we now know this test does something!
+So now let's run `cargo test`, you should be met by the 1 test passing again. However, we now know this test does something!
 
-Alright some of you more eagle-eyed readers may have noticed our test does not cover the other scenario with our `InstantiateMsg`. This leads me on to our next section:
+Alright, some of you more eagle-eyed readers may have noticed our test does not cover the other scenario with our `InstantiateMsg`. This leads me on to our next section:
 
 ## Follow Up Exercises
 
@@ -160,4 +160,4 @@ Alright now we're getting into this, I'm going to set some follow-up exercises f
         - You should use `ADDR2` as your specified admin.
         - How is our `assert_eq!` call going to be different?
 
-That's it for this part, as always thanks for reading all!
+That's it for this part, as always thanks for reading it all!

--- a/07 - Instantiate Test/SOLUTIONS.md
+++ b/07 - Instantiate Test/SOLUTIONS.md
@@ -1,6 +1,6 @@
 # Follow Up Exercises Solutions
 
-So you attempted the follow up exercises, I'm going to give solutions in snippet format.
+So you attempted the follow-up exercises, I'm going to give solutions in snippet format.
 
 ## Exercise 1
 

--- a/08 - ExecuteMsg/README.md
+++ b/08 - ExecuteMsg/README.md
@@ -1,8 +1,8 @@
 # Part Eight - ExecuteMsg
 
-Alright it's time to head back to a file we're familiar with. `src/msg.rs`.
+Alright, it's time to head back to a file we're familiar with. `src/msg.rs`.
 
-You've written messages before, so I have faith you'll pick this up pretty quick. We're going to add the backbone of our execute structure today. Well not the backbone more the start of it.
+You've written messages before, so I have faith you'll pick this up pretty quick. We're going to add the backbone of our execute structure today. Well, not the backbone more the start of it.
 
 We're not implementing the logic of these purely the messages which lead to the logic.
 
@@ -20,18 +20,18 @@ pub enum ExecuteMsg {
 // Following code omitted
 ```
 
-Alright let's draw some differences to `InstantiateMsg`. `ExecuteMsg` is an enum so it can contain a whole array of values. To put in plain terms, we only have one type of `InstantiateMsg` but we already have two types of `ExecuteMsg` (`Create a Poll` and `Vote on a Poll`).
+Alright, let's draw some differences to `InstantiateMsg`. `ExecuteMsg` is an enum so it can contain a whole array of values. To put it in plain terms, we only have one type of `InstantiateMsg` but we already have two types of `ExecuteMsg` (`Create a Poll` and `Vote on a Poll`).
 
 So how does this change how we write code for it? Not much really, let's run you through an example for `Creating a Poll`.
 
-First let's think of what information we need when creating a poll. It might be worth going back to look at the `State` chapter or looking in `src/state.rs` to refresh yourself. Let's talk it through part-by-part:
+First, let's think of what information we need when creating a poll. It might be worth going back to look at the `State` chapter or looking in `src/state.rs` to refresh yourself. Let's talk it through part by part:
 
 -   Creator - This can be inferred using the helper `info` variable I explained during the `Instantiate` chapter. We don't need this in our `CreatePoll` message.
 -   Question - User specified, definitely needs to be in the message. So we need a `String` question in our `CreatePoll` message.
 -   Options - User specified, definitely needs to be in the message. So we need a `Vec<String>` in our message. (As all vote counts start at 0).
 -   Poll ID - Generated client side as it is a UUID. So we also need a `String` ID.
 
-So there's our three fields, so how does that look in code, well here it is if you haven't written it already:
+So there are our three fields, so how does that look in code, well here it is if you haven't written it already:
 
 ```rust
 // Previous code omitted
@@ -51,9 +51,9 @@ It's that simple, so let's go through the same process for casting a vote.
 
 -   Voter - This can be inferred using the helper `info` variable.
 -   Poll ID - We need to know what poll the user is voting on, must be passed via the client. So we need a `String` field.
--   Vote - What option is the user voting for. We need a `String` field for this too.
+-   Vote - What option is the user voting for? We need a `String` field for this too.
 
-The code for this looks like:
+The code for this looks like this:
 
 ```rust
 // Previous code omitted
@@ -73,13 +73,13 @@ pub enum ExecuteMsg {
 // Following code omitted
 ```
 
-There we go! In this section you've learned how to define different types of `ExecuteMsg`! Next section we will cover actually implementing the logic for them.
+There we go! In this section, you've learned how to define different types of `ExecuteMsg`! Next section we will cover implementing the logic for them.
 
 ## Follow Up Exercises
 
 1. How would you go about writing an `ExecuteMsg` for deleting a poll?
     - Hints
-        - What information would you need? Think about what we need to retrieve it from our `Map` in storage.
+        - What information would you need? Think about what we need to retrieve from our `Map` in storage.
 2. What if a user wanted to revoke their vote from a poll?
     - Hints
         - As above think about what information you need to retrieve their `Ballot` from the `Map` in storage.

--- a/09 - Execute 1/README.md
+++ b/09 - Execute 1/README.md
@@ -1,8 +1,8 @@
 # Part Nine - Execute 1
 
-Alright this is the first part where we will be writing core execution logic.
+This is the first part where we will be writing core execution logic.
 
-So we implemented our messages last time, lets take a look at `src/contract.rs` and more specifically that unimplemented execution function.
+So we implemented our messages last time, let's take a look at `src/contract.rs` and more specifically that unimplemented execution function.
 
 ```rust
 #[cfg_attr(not(feature = "library"), entry_point)]
@@ -16,9 +16,9 @@ pub fn execute(
 }
 ```
 
-Looks very empty right? Well as your contracts grow this will be a lot of the logic. This function effectively becomes a switch case (in Rust more specifically a match case) redirecting appropriate messages to appropriate function calls.
+Looks very empty right? Well as your contracts grow this will be a lot of the logic. This function effectively becomes a switch case (in Rust more specifically a matching case) redirecting appropriate messages to appropriate function calls.
 
-So let's start implementing this redirection! To start with we want to `match` the `msg` variable for all it's different types. Luckily Rust supports enum pattern matching.
+So let's start implementing this redirection! To start with we want to `match` the `msg` variable for all its different types. Luckily Rust supports enum pattern matching.
 
 ```rust
 #[cfg_attr(not(feature = "library"), entry_point)]
@@ -39,15 +39,15 @@ pub fn execute(
 }
 ```
 
-So lets talk throuugh what this actually does, well to start with it determines what type of message the `msg` variable is. It then destructures it into the variables that make up the message (the parts within the `{}`). Those variables line up with the ones we defined in the message last chapter.
+So let's talk through what this does, well to start with it determines what type of message the `msg` variable is. It then destructures it into the variables that make up the message (the parts within the `{}`). Those variables line up with the ones we defined in the message in the last chapter.
 
 And then the `=>` means it calls the function, in our case we simply use the `unimplemented!` macro as a placeholder.
 
-So lets start writing our first implementation. So I like to follow the following pattern for my `execute` and `query` messages. The entry point is `execute` but each message calls its own function often named after the message. For example for `CreatePoll` the function name would be `execute_create_poll` now at a glance I can tell that this function executes the create poll message.
+So let's start writing our first implementation. So I like to follow the following pattern for my `execute` and `query` messages. The entry point is `execute` but each message calls its function often named after the message. For example for `CreatePoll` the function name would be `execute_create_poll` now at a glance I can tell that this function executes the create a poll message.
 
 I also like the pass all the `deps`, `env`, and `info` variables to each execute function, as I may need them for logic within the body, for example accessing storage.
 
-We also need the relevant information, for our `CreatePoll` example this is the `poll_id`, `question` and `options`. So this is how our `execute` body is now going to look:
+We also need the relevant information, for our `CreatePoll` example, this is the `poll_id`, `question` and `options`. So this is how our `execute` body is now going to look:
 
 ```rust
 #[cfg_attr(not(feature = "library"), entry_point)]
@@ -87,9 +87,9 @@ fn execute_create_poll(
 
 We define the function with the corresponding types for the parameter and also match the return type of the root `execute` function. This allows us to return our function calls directly in the match case. We've handled the type `Result<Response, ContractError>` before in our `instantiate`.
 
-So lets start implementing the code right? First I want to introduce you to the `ContractError` type. So we need an error state, as the developer of this polling service we can say the max amount of options is 10. Anymore and we will throw an error.
+So let's start implementing the code right? First I want to introduce you to the `ContractError` type. So we need an error state, as the developer of this polling service, we can say the max amount of options is 10. Any more and we will throw an error.
 
-Now we can implement this error. Head to the `src/errors.rs` file. It should currently look like:
+Now we can implement this error. Head to the `src/errors.rs` file. It should currently look like this:
 
 ```rust
 use cosmwasm_std::StdError;
@@ -107,7 +107,7 @@ pub enum ContractError {
 
 It contains some basic errors already, the ability to construct an error from a Cosmwasm `StdError` and a base `Unauthorized` error.
 
-Lets add our new error, call it something clear. I'm going with `TooManyOptions`. Now let's discuss the `#[error("...")]` part above each error. This is what the errors string value will be, it allows support of custom arguments but for now we can simply hard code our string to something like `"Too many poll options"`. This is what our new `ContractError` enum will look like:
+Let's add our new error, call it something clear. I'm going with `TooManyOptions`. Now let's discuss the `#[error("...")]` part above each error. This is what the errors string value will be, it allows support of custom arguments but for now, we can simply hard code our string to something like `"Too many poll options"`. This is what our new `ContractError` enum will look like:
 
 ```rust
 use cosmwasm_std::StdError;
@@ -184,7 +184,7 @@ It then adds a tuple of `(option, 0)` to the back of the new mutable `Vec`.
 
 This means we now have our options in the correct format.
 
-Let's construct our `Poll` but firstly we need to import the struct and the `Map` in storage. This can be seen below:
+Let's construct our `Poll` but firstly we need to import the struct and the `Map` into storage. This can be seen below:
 
 ```rust
 // We can add it to our existing config imports
@@ -223,7 +223,7 @@ fn execute_create_poll(
 
 As hinted above it uses `info.sender` for the creator. It simply uses the `question` parameter with no further processing for its question. And it uses our newly created `opts` `Vec` for the options.
 
-So how do we use this? Well firstly we need to store it under a key, in our case `poll_id`. We also need to give it a value to store, in our case `poll`. It also requires `deps.storage` to store values for our contract. So putting this all together how does this look?
+So how do we use this? Well, firstly we need to store it under a key, in our case `poll_id`. We also need to give it a value to store, in our case `poll`. It also requires `deps.storage` to store values for our contract. So putting this all together how does this look?
 
 ```rust
 fn execute_create_poll(
@@ -255,9 +255,9 @@ fn execute_create_poll(
 }
 ```
 
-Remember we need to pass it a reference of our `poll` by prefixing it with the `&` character. What this function call effectively does is it takes our `deps.storage` and stores `poll` under the key `poll_id`. The suffixing `?` means it automatically unwraps the result throwing any errors, this is standard practice for storage as if it fails here we definitely want to tell the user.
+Remember we need to pass it a reference of our `poll` by prefixing it with the `&` character. What this function call effectively does is it takes our `deps.storage` and stores `poll` under the key `poll_id`. The suffixing `?` means it automatically unwraps the result throwing any errors, this is standard practice for storage as if it fails here we want to tell the user.
 
-And now we need to remove that pesky `unimplemented!`, lets just return a response similarly to how we did in `instantiate`.
+And now we need to remove that pesky `unimplemented!` so let's just return a response similar to how we did in `instantiate`.
 
 ```rust
 fn execute_create_poll(
@@ -289,12 +289,12 @@ fn execute_create_poll(
 }
 ```
 
-Looks very familiar doesn't it! But there we go, we have now created an endpoint to store our polls in storage.
+Looks very familiar, doesn't it? But there we go, we have now created an endpoint to store our polls in storage.
 
-In the next part we will cover the `Vote` execute endpoint.
+In the next part, we will cover the `Vote` execute endpoint.
 
 ## Follow Up Exercises
 
-1. Think about what attributes we could add to our response?
+1. Think about what attributes we could add to our response.
     - Hints
         - What information do you think would be useful to the user?

--- a/10 - Execute 2/README.md
+++ b/10 - Execute 2/README.md
@@ -1,6 +1,6 @@
 # Part Ten - Execute 2
 
-Alright so last time we implemented the `execute_create_poll` function. Now we are going to do the same for voting.
+So last time we implemented the `execute_create_poll` function. Now we are going to do the same for voting.
 
 So open up `src/contract.rs` and take a look. Your main `execute` call should look something like this:
 
@@ -25,7 +25,7 @@ pub fn execute(
 
 So I explained my structure in the last chapter, let's write the code for calling the `execute_vote` function. We'll pass all parameters such as `deps`, `env`, `info` as well as our `poll_id` and `vote`.
 
-This should look something like:
+This should look something like this:
 
 ```rust
 #[cfg_attr(not(feature = "library"), entry_point)]
@@ -62,11 +62,11 @@ fn execute_vote(
 // Following code omitted
 ```
 
-This should all feel familiar, it's why I'm no longer explaining it so in depth. You should start to pick up these patterns very quickly.
+This should all feel familiar, it's why I'm no longer explaining it so in-depth. You should start to pick up these patterns very quickly.
 
 Alright this function is more complex so let's take it slow and think of what we need to do:
 
-1. We need to a load a poll, check if it exists.
+1. We need to load a poll and check if it exists.
 2. We need to update a user's ballot and if they have already voted take one away from their old vote option.
 3. We need to increment the user's new vote option.
 4. We need to save the poll's new state as well as the ballot.
@@ -90,7 +90,7 @@ fn execute_vote(
 // Following code omitted
 ```
 
-We have to clone the `poll_id` as we plan to use it multiple times. I'll go over how we can optimise this in a later chapter.
+We have to clone the `poll_id` as we plan to use it multiple times. I'll go over how we can optimize this in a later chapter.
 
 Do you remember the match case we used? We can also use this over `Option` to cater for both states, `null` or a `Poll` value.
 
@@ -117,7 +117,7 @@ fn execute_vote(
 
 As you can see if a poll exists (the `Some` branch) we take that poll and store it in a now mutable `poll` variable, which will we use later.
 
-If a poll does not exist we simply error, for now I placed a placeholder `Unauthorized` error.
+If a poll does not exist we simply error, for now, I placed a placeholder `Unauthorized` error.
 
 So what is the next step, let's deal with the user's ballot and if it already exists. This is going to get complex so I'll show you it and talk you through it step by step.
 
@@ -176,23 +176,23 @@ fn execute_vote(
 So firstly we call update on the `BALLOTS` storage `Map`, we use `deps.storage` as standard and we create the composite key we defined in `src/state.rs`. We then define an action that will be called on the matching key.
 You can think of this action as an inline function or a lambda.
 
-This action takes in both scenarios where a ballot exists and where on does not. We need to handle both.
+This action takes in both scenarios where a ballot exists and where one does not. We need to handle both.
 
 So we use another trusty match case! The `Some` option is where a ballot already exists and is more complex as we need to decrement their old vote by one. We'll talk through this first.
 
-How I handle decrementing their vote count is by finding the position of it by using the old ballot (now contained in the `ballot` variable). To do this we use another action in the `position` function, `position` simply returns an `Option<usize>` of the position in the `Vec` or `None` if it is not. We conditionally return the position where `option.0 == ballot.option`. The first part (`option.0`) effectively translates to the first element of the options tuple we defined (`(String, u64)`) so we want to match it with whatever ballot was casted before. This will find us the index the vote count is stored in.
+How I handle decrementing their vote count is by finding the position of it by using the old ballot (now contained in the `ballot` variable). To do this we use another action in the `position` function, `position` simply returns an `Option<usize>` of the position in the `Vec` or `None` if it is not. We conditionally return the position where `option.0 == ballot.option`. The first part (`option.0`) effectively translates to the first element of the options tuple we defined (`(String, u64)`) so we want to match it with whatever ballot was cast before. This will find us the index the vote count is stored in.
 
 We simply unwrap the `Option` value it returns to assert success.
 
 The next line simply uses this index, now stored in `position_of_old_vote` to decrement the count by 1. The `.1` part means it is accessing the second part of the tuple (the `u64` part).
 
-We then simply want to return a new `Ballot` for the key to be set to, we do this by defining a new `Ballot` with the user specified vote and returning it using the `Ok` syntax to assert success.
+We then simply want to return a new `Ballot` for the key to be set to, we do this by defining a new `Ballot` with the user-specified vote and returning it using the `Ok` syntax to assert success.
 
 The other part is much simpler, if a user has not voted before, we can simply create their new ballot as we do not have to worry about their old vote.
 
 I promise this is as complex as it gets!
 
-So now we need to increment the count of their new vote by 1, some of you may have realised we can use the same pattern we use to decrement their old vote. Let me show you:
+So now we need to increment the count of their new vote by 1, some of you may have realized we can use the same pattern we use to decrement their old vote. Let me show you:
 
 ```rust
 // Previous code omitted
@@ -322,9 +322,9 @@ And that means you made it to the end of another chapter!
 
 ## Follow Up Exercises
 
-1. Implement a better error for if a poll does not exist. Call it `PollNotFound`
+1. Implement a better error if a poll does not exist. Call it `PollNotFound`
     - Hints
-        - Go back a chapter and check how we implemented the limit for options.
+        - Go back a single chapter and check how we implemented the limit for options.
 2. Add better attributes on the `Ok` call, this will help with testing in the next chapter
     - Hints
         - What would be useful to the user?

--- a/11 - Execute Tests/README.md
+++ b/11 - Execute Tests/README.md
@@ -1,6 +1,6 @@
 # Part Eleven - Execute Tests
 
-So last part we started adding some actual functionality to our smart contract. Allowing the user to create and vote on polls.
+In the last part, we started adding some actual functionality to our smart contract. Allowing the user to create and vote on polls.
 
 You guessed it, we need to test it!
 
@@ -12,7 +12,7 @@ So let's just quickly walk through the scenarios we want to test:
 4. Successful voting a poll we have already voted for.
 5. Unsuccessful voting a poll, (invalid option).
 
-That sound's like a lot to test! It's not I'm going to split it into a number of test functions.
+That sound's like a lot to test! It's not I'm going to split it into several test functions.
 
 1. `test_execute_create_poll_valid` - tests the valid creation of a poll. AKA we expect no errors.
 2. `test_execute_create_poll_invalid` - tests the invalid creation of a poll. AKA we expect errors.
@@ -23,10 +23,10 @@ So let's get started!
 
 ## Create Poll Valid Tests
 
-So lets define the valid state. We currently only perform one validation check, so our valid state is a poll
+So let's define the valid state. We currently only perform one validation check, so our valid state is a poll
 with less than 10 options.
 
-Alright lets define the test function, this was last covered 4 chapters ago so let me remind you. Remember this should be placed within the `mod tests {}` part in `src/contract.rs`.
+Alright, let's define the test function, this was last covered 4 chapters ago so let me remind you. Remember this should be placed within the `mod tests {}` part in `src/contract.rs`.
 
 ```rust
 #[test]
@@ -35,7 +35,7 @@ fn test_execute_create_poll_valid() {
 }
 ```
 
-We also need to import the `execute` entrypoint of the contract and the `ExecuteMsg` enum:
+We also need to import the `execute` entry point of the contract and the `ExecuteMsg` enum:
 
 ```rust
 // Can import it with the instantiate import
@@ -43,7 +43,7 @@ use crate::contract::{instantiate, execute};
 use crate::msg::{InstantiateMsg, ExecuteMsg};
 ```
 
-Right theres some more prework we need to do, what you ask? Well in order to execute on a contract it must be instantiated! So let's copy the instantiate code from our instantiate test and simplify it a bit. Here's what it looks like:
+Right here's some more pre-work we need to do, what you ask? Well, to execute a contract it must be instantiated! So let's copy the instantiate code from our instantiate test and simplify it a bit. Here's what it looks like:
 
 ```rust
 #[test]
@@ -59,7 +59,7 @@ fn test_execute_create_poll_valid() {
 
 We don't need to query the attributes as we already cover that in our dedicated instantiate test. We can simply `unwrap` the instantiate to assert success. We also `clone` `info` and `env` as we are going to use these throughout.
 
-Alright now we have instantiated our test contract, lets start writing some new code!
+Alright now we have instantiated our test contract, Let's start writing some new code!
 
 ```rust
 #[test]
@@ -84,7 +84,7 @@ fn test_execute_create_poll_valid() {
 }
 ```
 
-So we defined an exectute message of type `CreatePoll` and fill it in with valid values. (Less than 10 options). Sorry if your favourite coin isn't present, you could always add it!
+So we defined an execute message of type `CreatePoll` and fill it in with valid values. (Less than 10 options). Sorry if your favorite coin isn't present, you could always add it!
 
 So now we need to call our `execute` function with this info, so make sure you import it. Here's what it looks like:
 
@@ -116,9 +116,9 @@ fn test_execute_create_poll_valid() {
 
 So we call the `execute` function using our mocked `deps`, `env` and `info` and capture the result.
 
-Unwrapping will throw any errors if it fails. I'd recommend here if you've been following the follow up exercises to check the `res` variable's attributes, this will make our test more hardy.
+Unwrapping will throw any errors if it fails. I'd recommend here if you've been following the follow-up exercises to check the `res` variable's attributes, this will make our test more hardy.
 
-I'm merely showing you how so I won't get bogged down with this. For a refresh as to how go back to chapter 7. For now this test suits the purpose of this tutorial.
+I'm merely showing you how so I won't get bogged down with this. For a refresh as to how to go back to chapter 7. For now, this test suits the purpose of this tutorial.
 
 And there we have it, our first test done! You're really getting the hang of this you know!
 
@@ -126,7 +126,7 @@ Run `cargo test` in your terminal to see it in action!
 
 ## Create Poll Invalid Tests
 
-Alright this test needs the same setup, so I'm going to skip the explanation as we've already done it once! Here it is:
+Alright, this test needs the same setup, so I'm going to skip the explanation as we've already done it once! Here it is:
 
 ```rust
 #[test]
@@ -140,7 +140,7 @@ fn test_execute_create_poll_invalid() {
 }
 ```
 
-Alright so what does our invalid message look like? Well it needs 11 options, so let's get writing:
+Alright, so what does our invalid message look like? Well, it needs 11 options, so let's get writing:
 
 ```rust
 #[test]
@@ -174,7 +174,7 @@ fn test_execute_create_poll_invalid() {
 
 I know this code is ugly and hardcoded, my answer is: don't care it's a test case.
 
-So now we need to call execute, but how can we assert an error. We know `unwrap` assumes success, if only there was a way we could unwrap an error. (See where I'm going with this). Enter `unwrap_err`:
+So now we need to call execute, but how can we assert an error? We know `unwrap` assumes success, if only there was a way we could unwrap an error. (See where I'm going with this). Enter `unwrap_err`:
 
 ```rust
 #[test]
@@ -231,7 +231,7 @@ fn test_execute_vote_valid() {
 
 Similar to what we've seen before. But remember there is another prerequisite.
 
-We need a poll to vote on! So lets copy some more code from our `execute_create_poll_valid` test.
+We need a poll to vote on! So let's copy some more code from our `execute_create_poll_valid` test.
 
 ```rust
 #[test]
@@ -259,7 +259,7 @@ fn test_execute_vote_valid() {
 
 We've seen this code before that's why I'm brushing over it. If I lose you here I'd recommend going back over some earlier sections.
 
-Now onto some new code, lets define a `Vote` message. This will be our initial vote (no existing `Ballot`) let's vote for Juno.
+Now onto some new code, let's define a `Vote` message. This will be our initial vote (no existing `Ballot`) let's vote for Juno.
 
 ```rust
 #[test]
@@ -294,7 +294,7 @@ fn test_execute_vote_valid() {
 
 Make sure the `poll_id` matches the one above, if you're worried extract it into a `String` variable and use that throughout.
 
-Once again we have a similar execute call, however this time with a vote message. If you added attributes to your `Vote` response, I'd recommend querying them here like we did in chapter 7.
+Once again we have a similar execute call, however this time with a vote message. If you added attributes to your `Vote` response, I'd recommend querying them here as we did in chapter 7.
 
 Now there's one more case we need to test, changing our vote.
 
@@ -371,7 +371,7 @@ fn test_execute_vote_invalid() {
 }
 ```
 
-Alright that's all familiar let's get to the new stuff. Lets take a vote from earlier but not create the poll to create our error case. Here's what mine looks like:
+Alright, that's all familiar let's get to the new stuff. Let's take a vote from earlier but not create the poll to create our error case. Here's what mine looks like:
 
 ```rust
 #[test]
@@ -393,11 +393,11 @@ fn test_execute_vote_invalid() {
 }
 ```
 
-Once again we call the trusty `unwrap_err` to assert failure. This should make sense as the `poll_id` `some_id` is not yet present in our lookup map, meaning the look up now fails.
+Once again we call the trusty `unwrap_err` to assert failure. This should make sense as the `poll_id` `some_id` is not yet present in our lookup map, meaning the look-up now fails.
 
-Alright that's our first error case checked off.
+Alright, that's our first error case checked off.
 
-Onto the next, but first we need to create a poll to test this one.
+Onto the next, but first, we need to create a poll to test this one.
 Let's copy over the Cosmos coin poll creation code:
 
 ```rust
@@ -474,7 +474,7 @@ fn test_execute_vote_invalid() {
 }
 ```
 
-As you can see the poll now exists. But the option does not, we are now testing for the different error!
+As you can see the poll now exists. But the option does not, we are now testing for a different error!
 
 So say it with me now! Let's unwrap that error!
 
@@ -521,14 +521,14 @@ And there we have it our last test.
 
 Run `cargo test` in your terminal to see them all running!
 
-I know this was a long chapter, but writing tests is critical for Cosmwasm development. You learn to love it, who doesn't love seeing 20 tests passed and 0 failed.
+I know this was a long chapter, but writing tests is critical for Cosmwasm development. You learn to love it, who doesn't love seeing 20 tests passed and 0 failed?
 
 ## Follow Up Exercises
 
-1. Think about what could improve the `valid` test cases?
+1. Think about what could improve the `valid` test cases.
     - Hints:
         - Think about adding some attributes to their `Ok` response and `assert_eq!` to check that they are as expected.
-2. Think about what could improve the `invalid` test cases?
+2. Think about what could improve the `invalid` test cases.
     - Hints:
-        - Think about adding some custom contract errors like we did before. Head into `src/errors.rs` and add them.
-        - How can we check these errors are what we expect? There's multiple ways too, I use a `match` like we do for different message types. If you're confused ask in the Juno discord dev lounge!
+        - Think about adding some custom contract errors as we did before. Head into `src/errors.rs` and add them.
+        - How can we check these errors are what we expect? There are multiple ways too, I use a `match` as we do for different message types. If you're confused ask in the Juno discord dev lounge!

--- a/12 - QueryMsg/README.md
+++ b/12 - QueryMsg/README.md
@@ -1,21 +1,21 @@
 # Part Twelve - QueryMsg
 
 So you're asking, we can change the state of our contract but what if we want to read some details?
-We don't need to pay transaction fees on that do we?
+We don't need to pay transaction fees on that, do we?
 
-No my friend, this is what querying is for!
+No, my friend, this is what querying is for!
 
-So as we did with all other sections lets head to where it starts `src/msg.rs`.
+So as we did with all other sections let's head to where it starts `src/msg.rs`.
 
 Now there should be a type of message that looks very empty and stands out, if you read the title of this chapter.
 
 QueryMsg allows us to query our contract's state, so let's think of some use cases we want for our eventual frontend dApp.
 
 1. Query all polls in a list format.
-2. Query a singular poll for a detail view.
-3. Query a user's vote for a given a poll.
+2. Query a singular poll for a detailed view.
+3. Query a user's vote for a given poll.
 
-These are vital for our functionality. Without them our website would suck and not work.
+These are vital for our functionality. Without them, our website would suck and not work.
 
 So like I did with the other message types. Let's think of what we need.
 
@@ -23,11 +23,11 @@ So for querying all polls, we don't particularly need anything. If we wanted to 
 
 For querying one all we need is the `poll_id` as that's the key of our map.
 
-For querying a user's vote we need a user's address and the `poll_id` of the poll as this is the key for our ballots map. I'll add the caviat here that due to this being a query we no longer have the `info` variable to determine the sender so the user's address must be contained in the message!
+For querying a user's vote we need a user's address and the `poll_id` of the poll as this is the key for our ballots map. I'll add the caveat here that due to this being a query we no longer have the `info` variable to determine the sender so the user's address must be contained in the message!
 
-Seems simple enough? Lets get to it.
+Seems simple enough? Let's get to it.
 
-Writing a QueryMsg is in fact the exact same as writing an ExecuteMsg, you'll pick this up in no time.
+Writing a QueryMsg is the same as writing an ExecuteMsg, you'll pick this up in no time.
 
 Starting with the simplest, `AllPolls` as it has no parameters. This is what it looks like:
 
@@ -81,7 +81,7 @@ pub enum QueryMsg {
 // Following code omitted
 ```
 
-We had to remove `QueryMsg::CustomMsg` in this enum, this has broken a helper in the `src/helpers.rs` file we need to remove, we can simply delete all code location in that file.
+We had to remove `QueryMsg::CustomMsg` in this enum, this has broken a helper in the `src/helpers.rs` file we need to remove, we can simply delete all code locations in that file.
 
 We can also remove the following code in `src/msg.rs` as it will not be used:
 
@@ -100,13 +100,13 @@ We also need to correct `examples/schema.rs` by changing the import from `src/ms
 use cw_starter::msg::{ExecuteMsg, InstantiateMsg, QueryMsg};
 ```
 
-Also remove the schema export for it:
+Also, remove the schema export for it:
 
 ```rust
 export_schema(&schema_for!(CustomResponse), &out_dir);
 ```
 
-There's our three messages, this should cover the basic functionality for this tutorial. Feel free to add your own routes, with smart contract development the world is your oyster.
+There are our three messages, this should cover the basic functionality of this tutorial. Feel free to add your routes, with smart contract development the world is your oyster.
 
 ## Follow Up Exercises
 
@@ -117,4 +117,4 @@ There's our three messages, this should cover the basic functionality for this t
 2. What might we have to do if we want to get all votes for a user?
     - Hints
         - This is pretty advanced, you may have to go dipping into the Cosmwasm docs or some advanced projects. I'd recommend looking at `cw3-dao` in the `dao-contracts` repo. [Repo](https://github.com/DA0-DA0/dao-contracts/tree/main/contracts/cw3-dao).
-        - If only there was a way to PREFIX query a map with a composite key? (Hint: I'm not being subtle here)
+        - If only there was a way to PREFIX query a map with a composite key. (Hint: I'm not being subtle here)

--- a/13 - Query/README.md
+++ b/13 - Query/README.md
@@ -1,12 +1,12 @@
 # Part Thirteen - Query
 
-So we need to a little more work in `src/msg.rs` before continuing, but first some background.
+So we need to do a little more work in `src/msg.rs` before continuing, but first some background.
 
 Query messages are handled differently when returning from a `query` you don't return via a `Response` you must define a custom struct which can then be encoded to `Binary`. This value is then decoded when using a query client on the front end side back into a helpful format AKA JSON.
 
-So how do we do this? Well it's all about defining structs and having them derive the correct features via macros.
+So how do we do this? Well, it's all about defining structs and having them derive the correct features via macros.
 
-So lets start by thinking about our `AllPolls` message and what we want to return. Well in a high-level translation we want to return a list of the `Poll` struct. How does this convert to rust? We use a `Vec<Poll>`. So here's how we define the struct.
+So let's start by thinking about our `AllPolls` message and what we want to return. Well in a high-level translation we want to return a list of the `Poll` struct. How does this convert to rust? We use a `Vec<Poll>`. So here's how we define the struct.
 
 Let's place it at the bottom of `src/msg.rs` and name it `AllPollsResponse` to make it clear what it is for.
 
@@ -21,11 +21,11 @@ pub struct AllPollsResponse {
 }
 ```
 
-Make sure both the struct AND the polls member variable is marked as public via the `pub` keyword.
+Make sure both the struct AND the polls member variable are marked as public via the `pub` keyword.
 
 The derivations support serializing too and from `Binary`.
 
-So we've done one let's think about our next one. `Poll` let's us pick one poll but a poll may not exist. The `Option` wrapper is perfect for this and deserializes nicely to `null` in JSON for our frontend later.
+So we've done one let's think about our next one. `Poll` lets us pick one poll but a poll may not exist. The `Option` wrapper is perfect for this and deserializes nicely to `null` in JSON for our frontend later.
 
 Here's how it looks:
 
@@ -53,7 +53,7 @@ pub struct VoteResponse {
 
 Looks very similar to our `PollResponse` but just using `Ballot` instead.
 
-Alright that's all the setup done, let's move to `src/contract.rs` and scroll down to our currently unimplemented query function. It should look something like this:
+Alright, that's all the setup done, let's move to `src/contract.rs` and scroll down to our currently unimplemented query function. It should look something like this:
 
 ```rust
 #[cfg_attr(not(feature = "library"), entry_point)]
@@ -62,7 +62,7 @@ pub fn query(_deps: Deps, _env: Env, _msg: QueryMsg) -> StdResult<Binary> {
 }
 ```
 
-Alright we're going to employ the same structure we used for ExecuteMsg, if you're not familiar with it head back to the corresponding chapter. Here's how it now looks:
+Alright, we're going to employ the same structure we used for ExecuteMsg, if you're not familiar with it head back to the corresponding chapter. Here's how it now looks:
 
 ```rust
 // Note the removal of the _s as we use these variables later
@@ -85,7 +85,7 @@ use cosmwasm_std::{Binary, Deps, DepsMut, Env, MessageInfo, Response, StdResult,
 use crate::msg::{ExecuteMsg, InstantiateMsg, QueryMsg, AllPollsResponse, PollResponse, VoteResponse};
 ```
 
-Let's start by implementing the `AllPoll` route, so lets define a new function `query_all_polls`, self explanatory right? Here's what it looks like:
+Let's start by implementing the `AllPoll` route, so let's define a new function `query_all_polls`, self-explanatory right? Here's what it looks like:
 
 ```rust
 // Previous code omitted
@@ -97,7 +97,7 @@ fn query_all_polls(deps: Deps, _env: Env) -> StdResult<Binary> {
 
 Notice we pass it `deps` and `env` as that's all we need. It also returns the same type `StdResult<Binary>` as `query` so we can return it directly.
 
-Now for a little bit of complex code, as we store our polls as a map, we need to retrieve all the values. In other languages such as Python this is often covered by a `.values()` call. In Cosmwasm it's a little different but I'll run you through:
+Now for a little bit of complex code, as we store our polls as a map, we need to retrieve all the values. In other languages such as Python, this is often covered by a `.values()` call. In Cosmwasm it's a little different but I'll run you through:
 
 ```rust
 // Previous code omitted
@@ -112,13 +112,13 @@ fn query_all_polls(deps: Deps, _env: Env) -> StdResult<Binary> {
 // Following code omitted
 ```
 
-So firstly we grab a range from polls using `deps.storage` to access it, the two `None`s mean we have no min amount and no max amount of values. `Order::Ascending` simply means return them in ascending order.
+So firstly we grab a range from polls using `deps.storage` to access it, the two `None`s mean we have no min amount and no max amount of values. `Order::Ascending` simply means returning them in ascending order.
 
-Next we have to do a little bit of processing using `map` with an action. This action must return an `StdResult<?>` so that's what the `Ok` is for, the type of `p` is a `Record<Poll>` so we must unwrap it, the `?`, and then it is a tuple. We want the second value the `.1` as the first is a `Vec` of bytes.
+Next, we have to do a little bit of processing using `map` with an action. This action must return an `StdResult<?>` so that's what the `Ok` is for, the type of `p` is a `Record<Poll>` so we must unwrap it, the `?`, and then it is a tuple. We want the second value the `.1` as the first is a `Vec` of bytes.
 
 Thirdly and finally we have to collect our results into a `Vec` wrapped by `StdResult`. We can use `_` for the type of the `Vec` as this can be inferred as a `Poll` from our map function.
 
-Alright that's the complex code for this chapter covered! Now let's get to returning a value.
+Alright, that's the complex code for this chapter covered! Now let's get to return a value.
 
 So as I implied earlier we have to convert our structs to `Binary`. Make sure you import our `AllPollsResponse` struct.
 
@@ -139,7 +139,7 @@ fn query_all_polls(deps: Deps, _env: Env) -> StdResult<Binary> {
 // Following code omitted
 ```
 
-In reality this query would need to be paginated with `start_after` variable and a max per page `limit` variable. But for the sake of this tutorial I'll keep it simple.
+In reality, this query would need to be paginated with `start_after` variable and a max per page `limit` variable. But for the sake of this tutorial, I'll keep it simple.
 
 Now we can go back to our `query` function and call this function.
 
@@ -154,7 +154,7 @@ pub fn query(deps: Deps, env: Env, msg: QueryMsg) -> StdResult<Binary> {
 }
 ```
 
-Lets work our way down, the code gets simpler from now I promise.
+Let's work our way down, the code gets simpler from now I promise.
 
 Define a `query_poll` function that takes `deps`, `env` and `poll_id`:
 
@@ -164,7 +164,7 @@ fn query_poll(deps: Deps, _env: Env, poll_id: String) -> StdResult<Binary> {
 }
 ```
 
-Alright now lets access our storage, I wonder if there's a helper function which lets us return an `Option<Poll>` instead of throwing an error if it is not present.
+Alright now let's access our storage, I wonder if there's a helper function that lets us return an `Option<Poll>` instead of throwing an error if it is not present.
 
 There is! It's the `may_load` function. Here's what it looks like:
 
@@ -198,7 +198,7 @@ pub fn query(deps: Deps, env: Env, msg: QueryMsg) -> StdResult<Binary> {
 }
 ```
 
-Onto our last one, this has the exact same problem as `query_poll` we need that `may_load` function again. Let's define the function first:
+Onto our last one, this has the same problem as `query_poll` we need that `may_load` function again. Let's define the function first:
 
 ```rust
 fn query_vote(deps: Deps, _env: Env, address: String, poll_id: String) -> StdResult<Binary> {
@@ -215,7 +215,7 @@ fn query_vote(deps: Deps, _env: Env, address: String, poll_id: String) -> StdRes
 }
 ```
 
-We `unwrap` it to assert success, this gives us the type `Addr` stored under `validate_address` which we can now use to key our map. Lets use the `may_load` function again to get the `Option<Ballot>` we need:
+We `unwrap` it to assert success, this gives us the type `Addr` stored under `validate_address` which we can now use to key our map. Let's use the `may_load` function again to get the `Option<Ballot>` we need:
 
 ```rust
 fn query_vote(deps: Deps, _env: Env, address: String, poll_id: String) -> StdResult<Binary> {
@@ -225,7 +225,7 @@ fn query_vote(deps: Deps, _env: Env, address: String, poll_id: String) -> StdRes
 }
 ```
 
-All very similar to what we have seen before now, and finally lets encode our result to `Binary`:
+All very similar to what we have seen before now, and finally let's encode our result to `Binary`:
 
 ```rust
 fn query_vote(deps: Deps, _env: Env, address: String, poll_id: String) -> StdResult<Binary> {
@@ -251,11 +251,11 @@ pub fn query(deps: Deps, env: Env, msg: QueryMsg) -> StdResult<Binary> {
 }
 ```
 
-Next chapter we will test these functions individually. For now we're done!
+Next chapter we will test these functions individually. For now, we're done!
 
 ## Follow Up Exercises
 
-1. If you implemented the `Config` query message I set in the follow up exercises before, implement and add the function needed for it to the `query` function:
+1. If you implemented the `Config` query message I set in the follow-up exercises before, implement and add the functionality needed for it to the `query` function:
     - Hints
         - It should only take a `deps` and `env` variable.
         - Remember you will need to define a response struct for it.

--- a/14 - Query Tests/README.md
+++ b/14 - Query Tests/README.md
@@ -1,6 +1,6 @@
 # Part Fourteen - Query Tests
 
-Alright we're back to testing, let's start taking a look at our testing section in `src/contract.rs`.
+We're back to testing, let's start taking a look at our testing section in `src/contract.rs`.
 
 Before we begin let's import what we will need:
 
@@ -24,7 +24,7 @@ fn test_query_all_polls() {
 // Following code omitted
 ```
 
-This should be second nature now. Similarly to our execute tests we need to instantiate the contract, lets copy over that code from another test:
+This should be second nature now. Similarly to our execute tests we need to instantiate the contract, lets's copy over that code from another test:
 
 ```rust
 // Previous code omitted
@@ -40,7 +40,7 @@ fn test_query_all_polls() {
 // Following code omitted
 ```
 
-We also need some polls to query! Lets pull in some execute code from our earlier tests, lets create two polls:
+We also need some polls to query! Let's pull in some executed code from our earlier tests, lets's create two polls:
 
 ```rust
 // Previous code omitted
@@ -78,7 +78,7 @@ fn test_query_all_polls() {
 
 We now have two polls so we expect two polls when we query our route.
 
-Lets start writing some new code, firstly we need to define a `msg` using our `QueryMsg` enum:
+Start writing some new code, firstly we need to define a `msg` using our `QueryMsg` enum:
 
 ```rust
 // Previous code omitted
@@ -117,11 +117,11 @@ fn test_query_all_polls() {
 // Following code omitted
 ```
 
-Looks very similar to our execute messages except we use the `QueryMsg` enum, and of course we want all polls so we use the `AllPoll`.
+Looks very similar to our execute messages except we use the `QueryMsg` enum, and of course, we want all polls so we use the `AllPoll`.
 
 Next up I'm going to cover the other side of why we need to encode our responses to `Binary`, now we need to decode them back to our structs.
 
-First lets get the raw binary and store it in a `bin` variable.
+First, get the raw binary and store it in a `bin` variable.
 
 ```rust
 // Previous code omitted
@@ -163,7 +163,7 @@ fn test_query_all_polls() {
 
 There is also a slight difference here, instead of using `deps.as_mut` which allows the dependencies to be mutable so we can change our contract state. We use `deps.as_ref` as queries cannot change the state of a contract.
 
-That seems simply enough, we now have the raw binary stored, but now you ask how do we decode it? Well Cosmwasm provides a helper `from_binary` for that. However when doing this we need to define a type for our variable so that `from_binary` knows what to expect.
+That seems simple enough, we now have the raw binary stored, but now you ask how do we decode it? Well, Cosmwasm provides a helper `from_binary` for that. However, when doing this we need to define a type for our variable so that `from_binary` knows what to expect.
 
 This is what it looks like:
 
@@ -208,7 +208,7 @@ fn test_query_all_polls() {
 
 Without the `AllPollsResponse` it would throw an error, `from_binary` also returns an `StdResult` so we `unwrap` it as we assume success.
 
-So now we have our struct we defined, we expect two polls to be contained in the `res.polls` variable. Lets assert this length using the `Vec` `.len()` method. Heres the code:
+So now we have the struct we defined, we expect two polls to be contained in the `res.polls` variable. Lets assert this length using the `Vec` `.len()` method. Here's the code:
 
 ```rust
 // Previous code omitted
@@ -252,10 +252,10 @@ fn test_query_all_polls() {
 
 That's our first test written and an overview of how to unit-test query routes. Run `cargo test` in your terminal to show that it is working!
 
-Lets now test the `Poll` route, there are two main cases:
+Let's now test the `Poll` route, there are two main cases:
 
-1. We query for a poll and it exists, expect the response to be `Some(poll)`.
-2. We query for a poll and it does not exist, expect the response to be `None`.
+1. We query for a poll and if it exists, expect the response to be `Some(poll)`.
+2. We query for a poll and if it does not exist, expect the response to be `None`.
 
 So let's outline our test, call it `test_query_poll`:
 
@@ -268,7 +268,7 @@ fn test_query_poll() {
 // Following code omitted
 ```
 
-Similarly to above we need to instantiate and create a poll, let's copy over some code to do that:
+Similarly to above, we need to instantiate and create a poll, let's copy over some code to do that:
 
 ```rust
 // Previous code omitted
@@ -298,7 +298,7 @@ fn test_query_poll() {
 
 This should now be second nature, I don't need to explain what this does now. If you are confused double back to our instantiate test and execute test chapters.
 
-So lets query for a poll that exists, here's what the message looks like:
+So let's query for a poll that exists, here's what the message looks like:
 
 ```rust
 // Previous code omitted
@@ -409,7 +409,7 @@ fn test_query_poll() {
 
 `assert!` is similar to `assert_eq!` except it expects the value to be true. It just makes the code simpler to write.
 
-So that's the first case covered, now let's copy that code expect change a few things. The first is to change `poll_id` to something that does not exist:
+So that's the first case covered, now let's copy that code except change a few things. The first is to change `poll_id` to something that does not exist:
 
 ```rust
 // Previous code omitted
@@ -453,7 +453,7 @@ fn test_query_poll() {
 
 I simply called my `poll_id`, `some_id_not_exist` to make it clear that it does not exist.
 
-Next we can copy the `Binary` decoding lines.
+Next, we can copy the `Binary` decoding lines.
 
 ```rust
 // Previous code omitted
@@ -545,7 +545,7 @@ fn test_query_poll() {
 
 Boom 2/3 tests done, run `cargo test` in your terminal to see it in action!
 
-Now onto our next test, lets call it `test_query_vote`:
+Now onto our next test, let's call it `test_query_vote`:
 
 ```rust
 // Previous code omitted
@@ -556,14 +556,14 @@ fn test_query_vote() {
 // Following code omitted
 ```
 
-Alright lets outline our test scenarios:
+Let's outline our test scenarios:
 
-1. Query for a vote that does exist, expect a value.
+1. Query for a vote that does exist, and expect a value.
 2. Query for a vote that does not exist, expect none.
 
 We also need to make sure we instantiate our contract, create a poll and create a vote.
 
-Lets bring over some code we've used before to do this:
+Let's bring over some code we've used before to do this:
 
 ```rust
 // Previous code omitted
@@ -600,7 +600,7 @@ fn test_query_vote() {
 
 I went fast over this as we've seen all this before.
 
-Let's outline our new query message, lets cover our vote that exists case, meaning we are querying for the vote on `poll_id` `some_id_1` and from address `ADDR1`.
+Let's outline our new query message, lets's cover our vote that exists case, meaning we are querying for the vote on `poll_id` `some_id_1` and from address `ADDR1`.
 
 ```rust
 // Previous code omitted
@@ -643,7 +643,7 @@ fn test_query_vote() {
 
 We use the `ADDR1` helper variable we defined right at the very start of the testing chapter.
 
-Now lets add the `Binary` code, remember to set the type of `res` to `VoteResponse`:
+Now let's add the `Binary` code, remember to set the type of `res` to `VoteResponse`:
 
 ```rust
 // Previous code omitted
@@ -735,7 +735,7 @@ fn test_query_vote() {
 
 This test is half done now, let's cover the other case!
 
-So we need to use a `poll_id` that does not exist, and hell why not lets also use a random address. We defined `ADDR2` for this use case earlier. Here's the message:
+So we need to use a `poll_id` that does not exist, and hell why not let's also use a random address. We defined `ADDR2` for this use case earlier. Here's the message:
 
 ```rust
 // Previous code omitted
@@ -788,7 +788,7 @@ fn test_query_vote() {
 
 As you can see we never create a poll with ID `some_id_2` and we also never created a vote using `ADDR2`.
 
-Next let's copy over the decoding code:
+Next, copy over the decoding code:
 
 ```rust
 // Previous code omitted
@@ -898,7 +898,7 @@ fn test_query_vote() {
 
 There we have it, our last test is complete. Run `cargo test` in your terminal to see all our tests running. Satisfying right?
 
-Next chapter will be a conclusion chapter for the smart contract side of this tutorial outlining some improvements and problems that I expect you to now have the knowledge to resolve. All in all this isn't the best implementation but you should now have the knowledge to go "Huh, I can probably do XYZ this way instead!". The world really is your oyster with smart contract development.
+The next chapter will be a conclusion chapter for the smart contract side of this tutorial outlining some improvements and problems that I expect you to now have the knowledge to resolve. All in all, this isn't the best implementation but you should now have the knowledge to go "Huh, I can probably do XYZ this way instead!". The world is your oyster with smart contract development.
 
 ## Follow Up Exercises
 

--- a/15 - Spring Cleaning/README.md
+++ b/15 - Spring Cleaning/README.md
@@ -1,6 +1,6 @@
 # Part Fifteen - Spring Cleaning
 
-I must admit, I've been neglecting some items. This chapter aims to remedy them and provide a couple other options to improve the contract.
+I must admit, I've been neglecting some items. This chapter aims to remedy them and provide a couple of other options to improve the contract.
 
 You've probably noticed some warnings when running console commands such as `cargo test`.
 
@@ -10,7 +10,7 @@ Let's start correcting them:
 
 ### Cargo Clippy
 
-Clippy provides a linter and if you've been pushing your project to github you'll notice a workflow defined which calls this command. The workflow will probably be failing unless you've been keeping ontop of this yourself.
+Clippy provides a linter and if you've been pushing your project to github you'll notice a workflow defined which calls this command. The workflow will probably be failing unless you've been keeping on top of this yourself.
 
 So here's how you can run it yourself:
 
@@ -69,7 +69,7 @@ error: useless use of `vec!`
 error: could not compile `cw-starter` due to 5 previous errors
 ```
 
-It shows tips on how to resolve them so I'm not going to cover that (and there's a lot). Instead I am simply going to correct them myself. The corrected code is available in `code/cw-starter` however I recommend you resolves these lints yourself and get in the habit of running `cargo clippy` yourself.
+It shows tips on how to resolve them so I'm not going to cover that (and there's a lot). Instead, I am simply going to correct them myself. The corrected code is available in `code/cw-starter` however I recommend you resolve these lints yourself and get in the habit of running `cargo clippy` yourself.
 
 ### Cargo FMT
 
@@ -95,11 +95,11 @@ cargo wasm
 cargo schema
 ```
 
-Rust provides some of the best tooling for linting, you'd be a fool not to use it!
+Rust provides some of the best toolings for linting, you'd be a fool not to use it!
 
 ## General Improvements
 
-You may notice in our `execute` code we often clone the strings as the values are "moved" in Rust terms. We can fix this by using references where we store strings in storage. For example keys for our maps can become (in `src/state.rs`):
+You may notice in our `execute` code we often clone the strings as the values are "moved" in Rust terms. We can fix this by using references where we store strings in storage. For example, keys for our maps can become (in `src/state.rs`):
 
 ```rust
 // Previous code omitted
@@ -130,29 +130,29 @@ BALLOTS.update(
 )?
 ```
 
-Again there's alot of changes to be made but your IDE should error where it hasn't been updated and the fixes are simple. This should be easy for you now!
+Again there are a lot of changes to be made but your IDE should error where it hasn't been updated and the fixes are simple. This should be easy for you now!
 
 Don't forget to check `clippy` and `fmt` after performing these upgrades!
 
 ## Functionality Improvements
 
-Now these changes won't be reflected under `code/cw-template` as these are optional and subjective.
+Now, these changes won't be reflected under `code/cw-template` as these are optional and subjective.
 
-It's down to you to now expand functionality of your contract! Here are some ideas:
+It's down to you to now expand the functionality of your contract! Here are some ideas:
 
 1. Charge users a 1 token fee for creating a poll to prevent spam.
     - Hints
         - The expected token denom must be stored in the global config items.
-        - `info` has a variable called `info.funds` which contains a `Vec<Coin>` think what we need to do to check that funds are sent and are of the correct type?
+        - `info` has a variable called `info.funds` which will contain a `Vec<Coin>` think what we need to do to check that funds are sent and are of the correct type.
         - Add an error if funds are not sent!
-        - Investigate how we can send funds in our unit-tests, look at the second parameter (currently an empty vec) in our `mock_info` calls.
+        - Investigate how we can send funds in our unit-tests, and look at the second parameter (currently an empty vec) in our `mock_info` calls.
         - Test for this error!
-2. Add a boolean field on a poll so it can be closed. User's cannot vote on a closed poll, throw an error if they attempt too.
+2. Add a boolean field on a poll so it can be closed. Users cannot vote on a closed poll and the program will throw an error if they attempt to.
     - Hints
         - We will need to modify our `Poll` type.
-        - We will need to mofiy our `Vote` execute endpoint to error if a poll is closed.
+        - We will need to modify our `Vote` execute endpoint to error if a poll is closed.
         - We will also need to add a new endpoint allowing the creator of a poll to close it.
-        - The global admin stored in config should also be able to close polls.
+        - The global admin stored in the config should also be able to close polls.
         - Error if anyone else tries to close a poll.
         - Add test cases for all use-cases listed above.
 3. When a poll is closed return the 1 token fee to the creator so it acts as a deposit and not a payment.
@@ -162,10 +162,10 @@ It's down to you to now expand functionality of your contract! Here are some ide
 
 ## Closing Notes on the Smart Contract Part of the Tutorial
 
-Well we've reached the end of the first part of contract development: next up building a dApp and providing a usable front-end.
+Well, we've reached the end of the first part of the contract development: next up building a dApp and providing a usable front-end.
 
-Actually there'll be one more chapter teaching you how to setup a local deployment to make testing your contract much much easier with your front end.
+There'll be one more chapter teaching you how to set up a local deployment to make testing your contract much easier with your front end.
 
-I'd like to thank you all for making it this far and the support I have received recently. If this tutorial has helped even just one person it makes it so worth it.
+I'd like to thank you all for making it this far and for the support I have received recently. If this tutorial has helped even just one person it makes it so worth it.
 
 Thanks again all, see you in the next part :).


### PR DESCRIPTION
Closes issue #10 

"let's" & "alright" are heavily used throughout. If you would like me to remove those let me know.

Used US based spelling, so "favorite" (without the u).

Other than that it was mainly just spacing, apostrophes, commas, and some other simple mistakes.